### PR TITLE
Add `$` as an alias of `command`

### DIFF
--- a/dist/alias.sh
+++ b/dist/alias.sh
@@ -2,3 +2,4 @@ alias tree="tree -NC" # N: 文字化け対策, C:色をつける
 alias v="code"
 alias gpp="g++"
 alias cr='cd "$(ghq root)/$(ghq list | fzf)"'
+alias '$'='command'


### PR DESCRIPTION
GitHub などでコマンドをコピーしたとき、プロンプトを表す $
もコピーされるので、$ があってもコマンドを実行できるようにする。